### PR TITLE
DOM-20543: Add empty string default for subscription id

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -94,4 +94,5 @@ variable "node_pools" {
 variable subscription_id {
   type        = string
   description = "An existing Subscription ID to add the deployment"
+  default     = ""
 }


### PR DESCRIPTION
Subscription id can be inferred from the running user, so we don't necessarily need to explicitly provide it; however, without the empty string default the module still ends up requiring it. Allow for that empty default so we can infer it if desired.