### PR TITLE
Use Managed Identity instead of SP

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = ">=2.3.0"
+  version = ">=2.7.0"
   features {}
 }
 
@@ -14,10 +14,6 @@ terraform {
 
 locals {
   cluster_name = var.cluster_name != null ? var.cluster_name : terraform.workspace
-}
-
-data "azurerm_subscription" "current" {
-  subscription_id = var.subscription_id
 }
 
 resource "azurerm_resource_group" "k8s" {
@@ -48,46 +44,6 @@ resource "azurerm_log_analytics_solution" "logs" {
     publisher = "Microsoft"
     product   = "OMSGallery/ContainerInsights"
   }
-}
-
-resource "azuread_application" "app" {
-  name = local.cluster_name
-
-
-  app_role {
-    allowed_member_types = [
-      "User",
-      "Application",
-    ]
-
-    description  = "Admins can manage roles and perform all task actions"
-    display_name = "Admin"
-    is_enabled   = true
-    value        = "Admin"
-  }
-}
-
-resource "random_password" "aks" {
-  length  = 24
-  special = true
-}
-
-resource "azuread_service_principal" "sp" {
-  application_id = azuread_application.app.application_id
-
-  tags = [local.cluster_name]
-}
-
-resource "azuread_service_principal_password" "sp" {
-  service_principal_id = azuread_service_principal.sp.id
-  value                = random_password.aks.result
-  end_date             = "2099-01-01T01:00:00Z"
-}
-
-resource "azurerm_role_assignment" "sp" {
-  scope                = data.azurerm_subscription.current.id
-  role_definition_name = "Owner"
-  principal_id         = azuread_service_principal.sp.object_id
 }
 
 resource "azurerm_kubernetes_cluster" "aks" {
@@ -122,9 +78,8 @@ resource "azurerm_kubernetes_cluster" "aks" {
     tags                  = {}
   }
 
-  service_principal {
-    client_id     = azuread_service_principal.sp.application_id
-    client_secret = azuread_service_principal_password.sp.value
+  identity {
+    type = "SystemAssigned"
   }
 
   addon_profile {

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   location                   = azurerm_resource_group.k8s.location
   resource_group_name        = azurerm_resource_group.k8s.name
   dns_prefix                 = local.cluster_name
-  private_link_enabled       = false
+  private_cluster_enabled    = false
 
   api_server_authorized_ip_ranges = var.api_server_authorized_ip_ranges
 

--- a/output.tf
+++ b/output.tf
@@ -1,7 +1,3 @@
 output "kubeconfig" {
   value = azurerm_kubernetes_cluster.aks.kube_config_raw
 }
-
-output "subscription_id" {
-  value = data.azurerm_subscription.current.subscription_id
-}

--- a/variables.tf
+++ b/variables.tf
@@ -90,9 +90,3 @@ variable "node_pools" {
     }
   }
 }
-
-variable subscription_id {
-  type        = string
-  description = "An existing Subscription ID to add the deployment"
-  default     = ""
-}


### PR DESCRIPTION
Service Principals (SP) expire and need to be manually renewed. A managed identity is a "wrapper" around a Service Principal that manages the expiration.

Currently, Terraform only supports SystemAssigned, rather than UserAssigned, Managed Identities. See [DOM-16944](https://dominodatalab.atlassian.net/browse/DOM-16944)

#### [Managed Identities Overview](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview)

#### [Use Managed Identity](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity)
>  Clusters using service principals eventually reach a state in which the service principal must be renewed to keep the cluster working. Managing service principals adds complexity, which is why it's easier to use managed identities instead. The same permission requirements apply for both service principals and managed identities.