### PR TITLE
DOM-77015: dataplane create flags + SKU refresh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
             curl -s --retry 10 --retry-delay 2 --retry-all-errors https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
             export TFSEC_VERSION=v1.28.14 #Pinning version toreduce GH calls to avoid rate limiting
             curl -s --retry 10 --retry-delay 2 --retry-all-errors https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
-            curl -L --retry 10 --retry-delay 2 --retry-all-errors https://github.com/terraform-docs/terraform-docs/releases/download/v0.20.0/terraform-docs-v0.20.0-linux-amd64.tar.gz | tar -C /tmp -xzf - && chmod +x /tmp/terraform-docs && sudo mv /tmp/terraform-docs /usr/local/bin
+            curl -L --retry 10 --retry-delay 2 --retry-all-errors https://github.com/terraform-docs/terraform-docs/releases/download/v0.21.0/terraform-docs-v0.21.0-linux-amd64.tar.gz | tar -C /tmp -xzf - && chmod +x /tmp/terraform-docs && sudo mv /tmp/terraform-docs /usr/local/bin
             pip3 install checkov pre-commit
             SKIP=no-commit-to-branch pre-commit run --all-files
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,27 @@ Access AKS cluster
 ## Development
 
 Please submit any feature enhancements, bug fixes, or ideas via pull requests or issues.
+
+## Dataplane mode
+
+For dataplane-only deployments (no Domino control plane), set the four `*_create` flags to `false` to skip CP-only resources:
+
+```hcl
+module "aks_cluster" {
+  source = "github.com/dominodatalab/terraform-azure-aks?ref=v3.0.0"
+
+  cluster                = "dp-cluster-name"
+  acr_create             = false
+  storage_create         = false
+  shared_storage_create  = false
+  hephaestus_create      = false
+}
+```
+
+The cluster, node pools, log analytics workspace, and AKS-managed identity are always created. Outputs for skipped resources return `null`; consumers must handle this.
+
+> **GPU note:** the default GPU node-pool SKU is now `Standard_NC24ads_A100_v4` (NCads_A100_v4 series). The previous default `Standard_NC6s_v3` was retired by Azure on 2025-09-30.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -51,8 +72,8 @@ Please submit any feature enhancements, bug fixes, or ideas via pull requests or
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.45 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.117.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.8.1 |
 
 ## Modules
 
@@ -117,6 +138,7 @@ Please submit any feature enhancements, bug fixes, or ideas via pull requests or
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_acr_create"></a> [acr\_create](#input\_acr\_create) | Whether to create the Azure Container Registry and related resources (tokens, role assignments, ACR credential refresher identity). Set to false for dataplane-only deployments that pull images from a remote registry. | `bool` | `true` | no |
 | <a name="input_acr_credential_refresher_service_account"></a> [acr\_credential\_refresher\_service\_account](#input\_acr\_credential\_refresher\_service\_account) | Kubernetes ServiceAccount name for the ACR credential refresher (must match nucleus chart: release-fullname + '-acr-credential-refresher'). | `string` | `"nucleus-acr-credential-refresher"` | no |
 | <a name="input_acr_genai_model_repository"></a> [acr\_genai\_model\_repository](#input\_acr\_genai\_model\_repository) | Repository path for Gen AI models in ACR. Used for repository-scoped token permissions. | `string` | `"dominodatalab/genai-model"` | no |
 | <a name="input_additional_node_pools"></a> [additional\_node\_pools](#input\_additional\_node\_pools) | additional node pools | <pre>map(object({<br/>    enable_node_public_ip = optional(bool, false)<br/>    vm_size               = string<br/>    zones                 = list(string)<br/>    node_labels           = map(string)<br/>    node_os               = optional(string, "AzureLinux")<br/>    node_taints           = optional(list(string), [])<br/>    enable_auto_scaling   = optional(bool, true)<br/>    min_count             = optional(number, 0)<br/>    max_count             = number<br/>    initial_count         = optional(number, 0)<br/>    max_pods              = optional(number, 30)<br/>    os_disk_size_gb       = optional(number, 128)<br/>  }))</pre> | `{}` | no |
@@ -129,13 +151,14 @@ Please submit any feature enhancements, bug fixes, or ideas via pull requests or
 | <a name="input_containers"></a> [containers](#input\_containers) | storage containers to create | <pre>map(object({<br/>    container_access_type = string<br/>  }))</pre> | <pre>{<br/>  "backups": {<br/>    "container_access_type": "private"<br/>  },<br/>  "projects": {<br/>    "container_access_type": "private"<br/>  }<br/>}</pre> | no |
 | <a name="input_deploy_id"></a> [deploy\_id](#input\_deploy\_id) | Domino Deployment ID. | `string` | n/a | yes |
 | <a name="input_dns_service_ip"></a> [dns\_service\_ip](#input\_dns\_service\_ip) | IP address assigned to the Kubernetes DNS service, used when CNI Overlay is enabled | `string` | `"100.97.0.10"` | no |
+| <a name="input_hephaestus_create"></a> [hephaestus\_create](#input\_hephaestus\_create) | Whether to create the Hephaestus image-builder managed identity and its federated credentials (hephaestus + importer). Set to false for dataplane-only deployments where image building runs on the control plane. | `bool` | `true` | no |
 | <a name="input_kubeconfig_output_path"></a> [kubeconfig\_output\_path](#input\_kubeconfig\_output\_path) | kubeconfig path | `string` | n/a | yes |
 | <a name="input_kubernetes_nat_gateway"></a> [kubernetes\_nat\_gateway](#input\_kubernetes\_nat\_gateway) | Managed NAT Gateway configuration | <pre>object({<br/>    idle_timeout_in_minutes   = optional(number, 4)<br/>    managed_outbound_ip_count = number<br/>    }<br/>  )</pre> | `null` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Optional Kubernetes version to provision. Allows partial input (e.g. 1.18) which is then chosen from azurerm\_kubernetes\_service\_versions. | `string` | `"1.34"` | no |
 | <a name="input_log_analytics_workspace_sku"></a> [log\_analytics\_workspace\_sku](#input\_log\_analytics\_workspace\_sku) | log analytics sku | `string` | `"PerGB2018"` | no |
 | <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | Namespace that are used for generating the service account bindings | `object({ platform = string, compute = string })` | n/a | yes |
 | <a name="input_node_os_upgrade_channel"></a> [node\_os\_upgrade\_channel](#input\_node\_os\_upgrade\_channel) | Option to enable automatic node OS upgrades.  Possible values are Unmanaged, SecurityPatch, NodeImage and None. | `string` | `"None"` | no |
-| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | default node pools | <pre>object({<br/>    compute = object({<br/>      enable_node_public_ip = optional(bool, false)<br/>      vm_size               = optional(string, "Standard_D8s_v4")<br/>      zones                 = optional(list(string), ["1", "2", "3"])<br/>      node_labels = optional(map(string), {<br/>        "dominodatalab.com/node-pool" = "default"<br/>      })<br/>      node_os             = optional(string, "AzureLinux")<br/>      node_taints         = optional(list(string), [])<br/>      enable_auto_scaling = optional(bool, true)<br/>      min_count           = optional(number, 0)<br/>      max_count           = optional(number, 10)<br/>      initial_count       = optional(number, 1)<br/>      max_pods            = optional(number, 30)<br/>      os_disk_size_gb     = optional(number, 128)<br/>    }),<br/>    platform = object({<br/>      enable_node_public_ip = optional(bool, false)<br/>      vm_size               = optional(string, "Standard_D8s_v4")<br/>      zones                 = optional(list(string), ["1", "2", "3"])<br/>      node_labels = optional(map(string), {<br/>        "dominodatalab.com/node-pool" = "platform"<br/>      })<br/>      node_os             = optional(string, "AzureLinux")<br/>      node_taints         = optional(list(string), [])<br/>      enable_auto_scaling = optional(bool, true)<br/>      min_count           = optional(number, 1)<br/>      max_count           = optional(number, 3)<br/>      initial_count       = optional(number, 1)<br/>      max_pods            = optional(number, 60)<br/>      os_disk_size_gb     = optional(number, 128)<br/>    }),<br/>    gpu = object({<br/>      enable_node_public_ip = optional(bool, false)<br/>      vm_size               = optional(string, "Standard_NC6s_v3")<br/>      zones                 = optional(list(string), [])<br/>      node_labels = optional(map(string), {<br/>        "dominodatalab.com/node-pool" = "default-gpu"<br/>        "nvidia.com/gpu"              = "true"<br/>      })<br/>      node_os = optional(string, "AzureLinux")<br/>      node_taints = optional(list(string), [<br/>        "nvidia.com/gpu=true:NoExecute"<br/>      ])<br/>      enable_auto_scaling = optional(bool, true)<br/>      min_count           = optional(number, 0)<br/>      max_count           = optional(number, 1)<br/>      initial_count       = optional(number, 0)<br/>      max_pods            = optional(number, 30)<br/>      os_disk_size_gb     = optional(number, 128)<br/>    })<br/>    system = object({<br/>      enable_node_public_ip = optional(bool, false)<br/>      vm_size               = optional(string, "Standard_DS4_v2")<br/>      zones                 = optional(list(string), ["1", "2", "3"])<br/>      node_labels           = optional(map(string), {})<br/>      node_os               = optional(string, "AzureLinux")<br/>      node_taints           = optional(list(string), [])<br/>      enable_auto_scaling   = optional(bool, true)<br/>      min_count             = optional(number, 1)<br/>      max_count             = optional(number, 6)<br/>      initial_count         = optional(number, 1)<br/>      max_pods              = optional(number, 60)<br/>      os_disk_size_gb       = optional(number, 128)<br/>    })<br/>  })</pre> | <pre>{<br/>  "compute": {},<br/>  "gpu": {},<br/>  "platform": {},<br/>  "system": {}<br/>}</pre> | no |
+| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | default node pools | <pre>object({<br/>    compute = object({<br/>      enable_node_public_ip = optional(bool, false)<br/>      vm_size               = optional(string, "Standard_D8s_v4")<br/>      zones                 = optional(list(string), ["1", "2", "3"])<br/>      node_labels = optional(map(string), {<br/>        "dominodatalab.com/node-pool" = "default"<br/>      })<br/>      node_os             = optional(string, "AzureLinux")<br/>      node_taints         = optional(list(string), [])<br/>      enable_auto_scaling = optional(bool, true)<br/>      min_count           = optional(number, 0)<br/>      max_count           = optional(number, 10)<br/>      initial_count       = optional(number, 1)<br/>      max_pods            = optional(number, 30)<br/>      os_disk_size_gb     = optional(number, 128)<br/>    }),<br/>    platform = object({<br/>      enable_node_public_ip = optional(bool, false)<br/>      vm_size               = optional(string, "Standard_D8s_v4")<br/>      zones                 = optional(list(string), ["1", "2", "3"])<br/>      node_labels = optional(map(string), {<br/>        "dominodatalab.com/node-pool" = "platform"<br/>      })<br/>      node_os             = optional(string, "AzureLinux")<br/>      node_taints         = optional(list(string), [])<br/>      enable_auto_scaling = optional(bool, true)<br/>      min_count           = optional(number, 1)<br/>      max_count           = optional(number, 3)<br/>      initial_count       = optional(number, 1)<br/>      max_pods            = optional(number, 60)<br/>      os_disk_size_gb     = optional(number, 128)<br/>    }),<br/>    gpu = object({<br/>      enable_node_public_ip = optional(bool, false)<br/>      vm_size               = optional(string, "Standard_NC24ads_A100_v4")<br/>      zones                 = optional(list(string), [])<br/>      node_labels = optional(map(string), {<br/>        "dominodatalab.com/node-pool" = "default-gpu"<br/>        "nvidia.com/gpu"              = "true"<br/>      })<br/>      node_os = optional(string, "AzureLinux")<br/>      node_taints = optional(list(string), [<br/>        "nvidia.com/gpu=true:NoExecute"<br/>      ])<br/>      enable_auto_scaling = optional(bool, true)<br/>      min_count           = optional(number, 0)<br/>      max_count           = optional(number, 1)<br/>      initial_count       = optional(number, 0)<br/>      max_pods            = optional(number, 30)<br/>      os_disk_size_gb     = optional(number, 128)<br/>    })<br/>    system = object({<br/>      enable_node_public_ip = optional(bool, false)<br/>      vm_size               = optional(string, "Standard_DS4_v2")<br/>      zones                 = optional(list(string), ["1", "2", "3"])<br/>      node_labels           = optional(map(string), {})<br/>      node_os               = optional(string, "AzureLinux")<br/>      node_taints           = optional(list(string), [])<br/>      enable_auto_scaling   = optional(bool, true)<br/>      min_count             = optional(number, 1)<br/>      max_count             = optional(number, 6)<br/>      initial_count         = optional(number, 1)<br/>      max_pods              = optional(number, 60)<br/>      os_disk_size_gb       = optional(number, 128)<br/>    })<br/>  })</pre> | <pre>{<br/>  "compute": {},<br/>  "gpu": {},<br/>  "platform": {},<br/>  "system": {}<br/>}</pre> | no |
 | <a name="input_pod_cidr"></a> [pod\_cidr](#input\_pod\_cidr) | CIDR block for Kubernetes pods, used when CNI Overlay is enabled | `string` | `"192.168.0.0/16"` | no |
 | <a name="input_private_acr_enabled"></a> [private\_acr\_enabled](#input\_private\_acr\_enabled) | Flag to determine whether to deploy a private ACR | `bool` | `false` | no |
 | <a name="input_private_cluster_enabled"></a> [private\_cluster\_enabled](#input\_private\_cluster\_enabled) | Flag to determine whether to deploy a private AKS | `bool` | `false` | no |
@@ -143,8 +166,10 @@ Please submit any feature enhancements, bug fixes, or ideas via pull requests or
 | <a name="input_registry_tier"></a> [registry\_tier](#input\_registry\_tier) | registry tier | `string` | `"Standard"` | no |
 | <a name="input_resource_group"></a> [resource\_group](#input\_resource\_group) | Name or id of optional pre-existing resource group to install AKS in | `string` | n/a | yes |
 | <a name="input_service_cidr"></a> [service\_cidr](#input\_service\_cidr) | CIDR block for Kubernetes services, used  when CNI Overlay is enabled | `string` | `"100.97.0.0/16"` | no |
+| <a name="input_shared_storage_create"></a> [shared\_storage\_create](#input\_shared\_storage\_create) | Whether to create the compute shared storage account, azurefile share, and supporting role assignments. Set to false for dataplane-only deployments using ephemeral block storage only. | `bool` | `true` | no |
 | <a name="input_storage_account_replication_type"></a> [storage\_account\_replication\_type](#input\_storage\_account\_replication\_type) | storage replication | `string` | `"LRS"` | no |
 | <a name="input_storage_account_tier"></a> [storage\_account\_tier](#input\_storage\_account\_tier) | storage account tier | `string` | `"Standard"` | no |
+| <a name="input_storage_create"></a> [storage\_create](#input\_storage\_create) | Whether to create the projects/backups blob storage account, containers, network rules, and private endpoints. Set to false for dataplane-only deployments where projects/backups blobs live on the control plane. | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources | `map(string)` | `{}` | no |
 | <a name="input_workspace_audit"></a> [workspace\_audit](#input\_workspace\_audit) | Workspace audit configuration | <pre>object({<br/>    enabled                       = optional(bool, false)<br/>    events_container_name         = optional(string, "workspace-audit-events-working")<br/>    events_archive_container_name = optional(string, "workspace-audit-events-archive")<br/>    container_access_type         = optional(string, "private")<br/>  })</pre> | `{}` | no |
 
@@ -154,12 +179,12 @@ Please submit any feature enhancements, bug fixes, or ideas via pull requests or
 |------|-------------|
 | <a name="output_acr_credential_refresher"></a> [acr\_credential\_refresher](#output\_acr\_credential\_refresher) | Configuration for ACR credential refresher Helm values |
 | <a name="output_aks_identity"></a> [aks\_identity](#output\_aks\_identity) | AKS managed identity |
-| <a name="output_blob_dns_zone_name"></a> [blob\_dns\_zone\_name](#output\_blob\_dns\_zone\_name) | blob dns zone name |
+| <a name="output_blob_dns_zone_name"></a> [blob\_dns\_zone\_name](#output\_blob\_dns\_zone\_name) | blob dns zone name (null when private cluster or storage account is disabled) |
 | <a name="output_containers"></a> [containers](#output\_containers) | storage details |
 | <a name="output_domino_acr"></a> [domino\_acr](#output\_domino\_acr) | Azure Container Registry details |
 | <a name="output_oidc_issuer_url"></a> [oidc\_issuer\_url](#output\_oidc\_issuer\_url) | OIDC issuer url |
 | <a name="output_private_cluster_enabled"></a> [private\_cluster\_enabled](#output\_private\_cluster\_enabled) | Flag to determine if AKS is private or public |
 | <a name="output_shared_storage_account"></a> [shared\_storage\_account](#output\_shared\_storage\_account) | shared storage account |
 | <a name="output_storage_account"></a> [storage\_account](#output\_storage\_account) | storage account |
-| <a name="output_workload_identities"></a> [workload\_identities](#output\_workload\_identities) | service identities |
+| <a name="output_workload_identities"></a> [workload\_identities](#output\_workload\_identities) | service identities (hephaestus null when hephaestus\_create=false) |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ module "aks_cluster" {
 }
 ```
 
-The cluster, node pools, log analytics workspace, and AKS-managed identity are always created. Outputs for skipped resources return `null`; consumers must handle this.
+The cluster, node pools, log analytics workspace, and AKS-managed identity are always created. Outputs for skipped resources return `null`; consumers must handle this. The `containers` output returns an empty map (`{}`) instead of `null` so consumers can safely iterate over it.
 
 > **GPU note:** the default GPU node-pool SKU is now `Standard_NC24ads_A100_v4` (NCads_A100_v4 series). The previous default `Standard_NC6s_v3` was retired by Azure on 2025-09-30.
 
@@ -180,7 +180,7 @@ The cluster, node pools, log analytics workspace, and AKS-managed identity are a
 | <a name="output_acr_credential_refresher"></a> [acr\_credential\_refresher](#output\_acr\_credential\_refresher) | Configuration for ACR credential refresher Helm values |
 | <a name="output_aks_identity"></a> [aks\_identity](#output\_aks\_identity) | AKS managed identity |
 | <a name="output_blob_dns_zone_name"></a> [blob\_dns\_zone\_name](#output\_blob\_dns\_zone\_name) | blob dns zone name (null when private cluster or storage account is disabled) |
-| <a name="output_containers"></a> [containers](#output\_containers) | storage details |
+| <a name="output_containers"></a> [containers](#output\_containers) | storage details (empty map when storage\_create=false; safe for iteration) |
 | <a name="output_domino_acr"></a> [domino\_acr](#output\_domino\_acr) | Azure Container Registry details |
 | <a name="output_oidc_issuer_url"></a> [oidc\_issuer\_url](#output\_oidc\_issuer\_url) | OIDC issuer url |
 | <a name="output_private_cluster_enabled"></a> [private\_cluster\_enabled](#output\_private\_cluster\_enabled) | Flag to determine if AKS is private or public |

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ The cluster, node pools, log analytics workspace, and AKS-managed identity are a
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.117.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.8.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.45 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The cluster, node pools, log analytics workspace, and AKS-managed identity are a
 | <a name="output_acr_credential_refresher"></a> [acr\_credential\_refresher](#output\_acr\_credential\_refresher) | Configuration for ACR credential refresher Helm values |
 | <a name="output_aks_identity"></a> [aks\_identity](#output\_aks\_identity) | AKS managed identity |
 | <a name="output_blob_dns_zone_name"></a> [blob\_dns\_zone\_name](#output\_blob\_dns\_zone\_name) | blob dns zone name (null when private cluster or storage account is disabled) |
-| <a name="output_containers"></a> [containers](#output\_containers) | storage details (empty map when storage\_create=false; safe for iteration) |
+| <a name="output_containers"></a> [containers](#output\_containers) | storage details (empty map when storage\_create=false; safe for iteration and key-lookup — type stays map(storage\_container) regardless of flag) |
 | <a name="output_domino_acr"></a> [domino\_acr](#output\_domino\_acr) | Azure Container Registry details |
 | <a name="output_oidc_issuer_url"></a> [oidc\_issuer\_url](#output\_oidc\_issuer\_url) | OIDC issuer url |
 | <a name="output_private_cluster_enabled"></a> [private\_cluster\_enabled](#output\_private\_cluster\_enabled) | Flag to determine if AKS is private or public |

--- a/acr-repository-token.tf
+++ b/acr-repository-token.tf
@@ -15,8 +15,9 @@
 
 # Scope map defining permissions for the genai-model repository
 resource "azurerm_container_registry_scope_map" "genai_model_pull" {
+  count                   = var.acr_create ? 1 : 0
   name                    = "${var.deploy_id}-genai-model-pull"
-  container_registry_name = azurerm_container_registry.domino.name
+  container_registry_name = azurerm_container_registry.domino[0].name
   resource_group_name     = data.azurerm_resource_group.aks.name
 
   actions = [
@@ -29,16 +30,18 @@ resource "azurerm_container_registry_scope_map" "genai_model_pull" {
 
 # Repository-scoped token
 resource "azurerm_container_registry_token" "genai_model_pull" {
+  count                   = var.acr_create ? 1 : 0
   name                    = "${var.deploy_id}-genai-model-pull"
-  container_registry_name = azurerm_container_registry.domino.name
+  container_registry_name = azurerm_container_registry.domino[0].name
   resource_group_name     = data.azurerm_resource_group.aks.name
-  scope_map_id            = azurerm_container_registry_scope_map.genai_model_pull.id
+  scope_map_id            = azurerm_container_registry_scope_map.genai_model_pull[0].id
   enabled                 = true
 }
 
 # Dual passwords allow zero-downtime rotation
 resource "azurerm_container_registry_token_password" "genai_model_pull" {
-  container_registry_token_id = azurerm_container_registry_token.genai_model_pull.id
+  count                       = var.acr_create ? 1 : 0
+  container_registry_token_id = azurerm_container_registry_token.genai_model_pull[0].id
 
   password1 {} # Primary - initial slot
   password2 {} # Secondary - enables grace period during rotation
@@ -51,6 +54,7 @@ resource "azurerm_container_registry_token_password" "genai_model_pull" {
 
 # Custom role definition for ACR token password regeneration
 resource "azurerm_role_definition" "acr_token_credential_generator" {
+  count       = var.acr_create ? 1 : 0
   name        = "${var.deploy_id}-acr-token-credential-generator"
   scope       = data.azurerm_subscription.current.id
   description = "Allows regenerating ACR repository-scoped token passwords. Used by the credential refresher CronJob for rotation."
@@ -64,6 +68,6 @@ resource "azurerm_role_definition" "acr_token_credential_generator" {
   }
 
   assignable_scopes = [
-    azurerm_container_registry.domino.id
+    azurerm_container_registry.domino[0].id
   ]
 }

--- a/acr-repository-token.tf
+++ b/acr-repository-token.tf
@@ -71,3 +71,26 @@ resource "azurerm_role_definition" "acr_token_credential_generator" {
     azurerm_container_registry.domino[0].id
   ]
 }
+
+#===============================================================================
+# State Migration
+#===============================================================================
+moved {
+  from = azurerm_container_registry_scope_map.genai_model_pull
+  to   = azurerm_container_registry_scope_map.genai_model_pull[0]
+}
+
+moved {
+  from = azurerm_container_registry_token.genai_model_pull
+  to   = azurerm_container_registry_token.genai_model_pull[0]
+}
+
+moved {
+  from = azurerm_container_registry_token_password.genai_model_pull
+  to   = azurerm_container_registry_token_password.genai_model_pull[0]
+}
+
+moved {
+  from = azurerm_role_definition.acr_token_credential_generator
+  to   = azurerm_role_definition.acr_token_credential_generator[0]
+}

--- a/acr.tf
+++ b/acr.tf
@@ -85,3 +85,21 @@ resource "azurerm_role_assignment" "aks_domino_private_acr" {
   role_definition_name = "AcrPull"
   principal_id         = azurerm_user_assigned_identity.aks_assigned_identity[0].principal_id
 }
+
+#########################################################################
+########################## State Migration ##############################
+#########################################################################
+moved {
+  from = azurerm_container_registry.domino
+  to   = azurerm_container_registry.domino[0]
+}
+
+moved {
+  from = azurerm_role_assignment.aks_domino_acr
+  to   = azurerm_role_assignment.aks_domino_acr[0]
+}
+
+moved {
+  from = azurerm_role_assignment.hephaestus_acr
+  to   = azurerm_role_assignment.hephaestus_acr[0]
+}

--- a/acr.tf
+++ b/acr.tf
@@ -4,6 +4,7 @@
 # Create ACR registry for Domino images
 resource "azurerm_container_registry" "domino" {
   #checkov:skip=CKV_AZURE_237: "Ensure dedicated data endpoints are enabled."
+  count                         = var.acr_create ? 1 : 0
   name                          = replace("${data.azurerm_resource_group.aks.name}domino", "/[^a-zA-Z0-9]/", "")
   resource_group_name           = data.azurerm_resource_group.aks.name
   location                      = data.azurerm_resource_group.aks.location
@@ -31,13 +32,13 @@ resource "azurerm_container_registry" "domino" {
 #########################################################################
 # create private dns zone for acr
 resource "azurerm_private_dns_zone" "acr_private_dns_zone" {
-  count               = var.private_acr_enabled ? 1 : 0
+  count               = var.private_acr_enabled && var.acr_create ? 1 : 0
   name                = "privatelink.azurecr.io"
   resource_group_name = data.azurerm_resource_group.aks.name
 }
 # link the dns private zone to the AKS VNET
 resource "azurerm_private_dns_zone_virtual_network_link" "private_dns_zone_acr_vnet_link" {
-  count                 = var.private_acr_enabled ? 1 : 0
+  count                 = var.private_acr_enabled && var.acr_create ? 1 : 0
   name                  = "acr-vnet-dns-link"
   resource_group_name   = data.azurerm_resource_group.aks.name
   private_dns_zone_name = azurerm_private_dns_zone.acr_private_dns_zone[0].name
@@ -48,9 +49,9 @@ resource "azurerm_private_dns_zone_virtual_network_link" "private_dns_zone_acr_v
 #########################################################################
 # Create a private endpoint for the ACR
 module "domino_acr_ep" {
-  count                 = var.private_acr_enabled ? 1 : 0
+  count                 = var.private_acr_enabled && var.acr_create ? 1 : 0
   source                = "./modules/private_endpoint"
-  resource_id           = azurerm_container_registry.domino.id
+  resource_id           = azurerm_container_registry.domino[0].id
   nic_name              = "acr-${var.deploy_id}"
   private_endpoint_name = "acr-${var.deploy_id}"
   private_dns_zone      = azurerm_private_dns_zone.acr_private_dns_zone[0].name
@@ -65,20 +66,22 @@ module "domino_acr_ep" {
 #########################################################################
 # ACR Pull from AKS nodes
 resource "azurerm_role_assignment" "aks_domino_acr" {
-  scope                = azurerm_container_registry.domino.id
+  count                = var.acr_create ? 1 : 0
+  scope                = azurerm_container_registry.domino[0].id
   role_definition_name = "AcrPull"
   principal_id         = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
 }
 # ACR Push from hepheastus
 resource "azurerm_role_assignment" "hephaestus_acr" {
-  scope                = azurerm_container_registry.domino.id
+  count                = var.acr_create ? 1 : 0
+  scope                = azurerm_container_registry.domino[0].id
   role_definition_name = "AcrPush"
   principal_id         = azurerm_user_assigned_identity.hephaestus.principal_id
 }
 # ACR Pull from private AKS nodes
 resource "azurerm_role_assignment" "aks_domino_private_acr" {
-  count                = var.private_cluster_enabled ? 1 : 0
-  scope                = azurerm_container_registry.domino.id
+  count                = var.private_cluster_enabled && var.acr_create ? 1 : 0
+  scope                = azurerm_container_registry.domino[0].id
   role_definition_name = "AcrPull"
   principal_id         = azurerm_user_assigned_identity.aks_assigned_identity[0].principal_id
 }

--- a/acr.tf
+++ b/acr.tf
@@ -73,10 +73,10 @@ resource "azurerm_role_assignment" "aks_domino_acr" {
 }
 # ACR Push from hepheastus
 resource "azurerm_role_assignment" "hephaestus_acr" {
-  count                = var.acr_create ? 1 : 0
+  count                = var.acr_create && var.hephaestus_create ? 1 : 0
   scope                = azurerm_container_registry.domino[0].id
   role_definition_name = "AcrPush"
-  principal_id         = azurerm_user_assigned_identity.hephaestus.principal_id
+  principal_id         = azurerm_user_assigned_identity.hephaestus[0].principal_id
 }
 # ACR Pull from private AKS nodes
 resource "azurerm_role_assignment" "aks_domino_private_acr" {

--- a/identities.tf
+++ b/identities.tf
@@ -82,6 +82,7 @@ resource "azurerm_federated_identity_credential" "importer" {
 
 # Create ACR Credential Refresher identity
 resource "azurerm_user_assigned_identity" "acr_credential_refresher" {
+  count               = var.acr_create ? 1 : 0
   name                = "${var.deploy_id}-acr-credential-refresher"
   resource_group_name = data.azurerm_resource_group.aks.name
   location            = data.azurerm_resource_group.aks.location
@@ -94,9 +95,10 @@ resource "azurerm_user_assigned_identity" "acr_credential_refresher" {
 
 # Grants the identity permission to call ACR generateCredentials so the CronJob can rotate token passwords
 resource "azurerm_role_assignment" "acr_credential_refresher" {
-  scope              = azurerm_container_registry.domino.id
-  role_definition_id = azurerm_role_definition.acr_token_credential_generator.role_definition_resource_id
-  principal_id       = azurerm_user_assigned_identity.acr_credential_refresher.principal_id
+  count              = var.acr_create ? 1 : 0
+  scope              = azurerm_container_registry.domino[0].id
+  role_definition_id = azurerm_role_definition.acr_token_credential_generator[0].role_definition_resource_id
+  principal_id       = azurerm_user_assigned_identity.acr_credential_refresher[0].principal_id
 
   lifecycle {
     create_before_destroy = true
@@ -105,9 +107,10 @@ resource "azurerm_role_assignment" "acr_credential_refresher" {
 
 # Allows the Kubernetes ServiceAccount to authenticate as the managed identity via Workload Identity
 resource "azurerm_federated_identity_credential" "acr_credential_refresher" {
+  count               = var.acr_create ? 1 : 0
   name                = "${var.deploy_id}-acr-credential-refresher"
   resource_group_name = data.azurerm_resource_group.aks.name
-  parent_id           = azurerm_user_assigned_identity.acr_credential_refresher.id
+  parent_id           = azurerm_user_assigned_identity.acr_credential_refresher[0].id
   audience            = ["api://AzureADTokenExchange"]
   issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
   subject             = "system:serviceaccount:${var.namespaces.platform}:${var.acr_credential_refresher_service_account}"

--- a/identities.tf
+++ b/identities.tf
@@ -119,3 +119,21 @@ resource "azurerm_federated_identity_credential" "acr_credential_refresher" {
     azurerm_kubernetes_cluster.aks
   ]
 }
+
+#########################################################################
+########################## State Migration ##############################
+#########################################################################
+moved {
+  from = azurerm_user_assigned_identity.acr_credential_refresher
+  to   = azurerm_user_assigned_identity.acr_credential_refresher[0]
+}
+
+moved {
+  from = azurerm_role_assignment.acr_credential_refresher
+  to   = azurerm_role_assignment.acr_credential_refresher[0]
+}
+
+moved {
+  from = azurerm_federated_identity_credential.acr_credential_refresher
+  to   = azurerm_federated_identity_credential.acr_credential_refresher[0]
+}

--- a/identities.tf
+++ b/identities.tf
@@ -3,6 +3,7 @@
 #########################################################################
 # Create Hephaestus identity
 resource "azurerm_user_assigned_identity" "hephaestus" {
+  count               = var.hephaestus_create ? 1 : 0
   name                = "hephaestus"
   location            = data.azurerm_resource_group.aks.location
   resource_group_name = data.azurerm_resource_group.aks.name
@@ -10,11 +11,12 @@ resource "azurerm_user_assigned_identity" "hephaestus" {
 }
 # Create Hephaestus identity credentials
 resource "azurerm_federated_identity_credential" "hephaestus" {
+  count               = var.hephaestus_create ? 1 : 0
   name                = "hephaestus"
   resource_group_name = data.azurerm_resource_group.aks.name
   audience            = ["api://AzureADTokenExchange"]
   issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
-  parent_id           = azurerm_user_assigned_identity.hephaestus.id
+  parent_id           = azurerm_user_assigned_identity.hephaestus[0].id
   subject             = "system:serviceaccount:${var.namespaces.compute}:hephaestus"
 }
 # create user assigned identity for AKS
@@ -73,11 +75,12 @@ resource "azurerm_role_assignment" "aks_domino_shared" {
 }
 # Data importer identity credentials
 resource "azurerm_federated_identity_credential" "importer" {
+  count               = var.hephaestus_create ? 1 : 0
   name                = "importer"
   resource_group_name = data.azurerm_resource_group.aks.name
   audience            = ["api://AzureADTokenExchange"]
   issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
-  parent_id           = azurerm_user_assigned_identity.hephaestus.id
+  parent_id           = azurerm_user_assigned_identity.hephaestus[0].id
   subject             = "system:serviceaccount:${var.namespaces.platform}:domino-data-importer"
 }
 
@@ -142,4 +145,19 @@ moved {
 moved {
   from = azurerm_role_assignment.aks_domino_shared
   to   = azurerm_role_assignment.aks_domino_shared[0]
+}
+
+moved {
+  from = azurerm_user_assigned_identity.hephaestus
+  to   = azurerm_user_assigned_identity.hephaestus[0]
+}
+
+moved {
+  from = azurerm_federated_identity_credential.hephaestus
+  to   = azurerm_federated_identity_credential.hephaestus[0]
+}
+
+moved {
+  from = azurerm_federated_identity_credential.importer
+  to   = azurerm_federated_identity_credential.importer[0]
 }

--- a/identities.tf
+++ b/identities.tf
@@ -29,8 +29,8 @@ resource "azurerm_user_assigned_identity" "aks_assigned_identity" {
 }
 # Assign identity permissions on fileshare storage account
 resource "azurerm_role_assignment" "aks_file_share_contributor" {
-  count                = local.private_shared_enabled ? 1 : 0
-  scope                = azurerm_storage_account.domino_shared.id
+  count                = local.private_shared_enabled && var.shared_storage_create ? 1 : 0
+  scope                = azurerm_storage_account.domino_shared[0].id
   role_definition_name = "Storage Account Contributor"
   principal_id         = var.private_cluster_enabled ? azurerm_user_assigned_identity.aks_assigned_identity[0].principal_id : azurerm_kubernetes_cluster.aks.identity[0].principal_id
 }
@@ -66,7 +66,8 @@ resource "azurerm_role_assignment" "identity_assign_vnet" {
 }
 # Storage Accounts listKeys from AKS nodes
 resource "azurerm_role_assignment" "aks_domino_shared" {
-  scope                = azurerm_storage_account.domino_shared.id
+  count                = var.shared_storage_create ? 1 : 0
+  scope                = azurerm_storage_account.domino_shared[0].id
   role_definition_name = "Storage Account Key Operator Service Role"
   principal_id         = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
 }
@@ -136,4 +137,9 @@ moved {
 moved {
   from = azurerm_federated_identity_credential.acr_credential_refresher
   to   = azurerm_federated_identity_credential.acr_credential_refresher[0]
+}
+
+moved {
+  from = azurerm_role_assignment.aks_domino_shared
+  to   = azurerm_role_assignment.aks_domino_shared[0]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,9 +29,9 @@ output "domino_acr" {
 }
 
 output "workload_identities" {
-  description = "service identities"
+  description = "service identities (hephaestus null when hephaestus_create=false)"
   value = {
-    "hephaestus" = azurerm_user_assigned_identity.hephaestus
+    hephaestus = var.hephaestus_create ? azurerm_user_assigned_identity.hephaestus[0] : null
   }
 }
 output "blob_dns_zone_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ output "storage_account" {
 
 output "shared_storage_account" {
   description = "shared storage account"
-  value       = azurerm_storage_account.domino_shared
+  value       = var.shared_storage_create ? azurerm_storage_account.domino_shared[0] : null
 }
 
 output "aks_identity" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "containers" {
-  description = "storage details (empty map when storage_create=false; safe for iteration)"
-  value       = var.storage_create ? azurerm_storage_container.domino_containers : {}
+  description = "storage details (empty map when storage_create=false; safe for iteration and key-lookup — type stays map(storage_container) regardless of flag)"
+  value       = azurerm_storage_container.domino_containers
 }
 
 output "storage_account" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,11 @@
 output "containers" {
   description = "storage details"
-  value       = azurerm_storage_container.domino_containers
+  value       = var.storage_create ? azurerm_storage_container.domino_containers : null
 }
 
 output "storage_account" {
   description = "storage account"
-  value       = azurerm_storage_account.domino
+  value       = var.storage_create ? azurerm_storage_account.domino[0] : null
 }
 
 output "shared_storage_account" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,7 +25,7 @@ output "oidc_issuer_url" {
 
 output "domino_acr" {
   description = "Azure Container Registry details"
-  value       = azurerm_container_registry.domino
+  value       = var.acr_create ? azurerm_container_registry.domino[0] : null
 }
 
 output "workload_identities" {
@@ -50,12 +50,12 @@ output "private_cluster_enabled" {
 #===============================================================================
 output "acr_credential_refresher" {
   description = "Configuration for ACR credential refresher Helm values"
-  value = {
-    identity_client_id = azurerm_user_assigned_identity.acr_credential_refresher.client_id
+  value = var.acr_create ? {
+    identity_client_id = azurerm_user_assigned_identity.acr_credential_refresher[0].client_id
     subscription_id    = data.azurerm_subscription.current.subscription_id
     resource_group     = data.azurerm_resource_group.aks.name
-    registry_name      = azurerm_container_registry.domino.name
-    registry_server    = azurerm_container_registry.domino.login_server
-    token_name         = azurerm_container_registry_token.genai_model_pull.name
-  }
+    registry_name      = azurerm_container_registry.domino[0].name
+    registry_server    = azurerm_container_registry.domino[0].login_server
+    token_name         = azurerm_container_registry_token.genai_model_pull[0].name
+  } : null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,8 +35,8 @@ output "workload_identities" {
   }
 }
 output "blob_dns_zone_name" {
-  description = "blob dns zone name"
-  value       = var.private_cluster_enabled ? azurerm_private_dns_zone.blob_private_dns_zone[0].name : null
+  description = "blob dns zone name (null when private cluster or storage account is disabled)"
+  value       = var.private_cluster_enabled && var.storage_create ? azurerm_private_dns_zone.blob_private_dns_zone[0].name : null
 }
 
 output "private_cluster_enabled" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "containers" {
-  description = "storage details"
-  value       = var.storage_create ? azurerm_storage_container.domino_containers : null
+  description = "storage details (empty map when storage_create=false; safe for iteration)"
+  value       = var.storage_create ? azurerm_storage_container.domino_containers : {}
 }
 
 output "storage_account" {

--- a/storage.tf
+++ b/storage.tf
@@ -180,6 +180,7 @@ locals {
   )
 }
 resource "azurerm_storage_container" "domino_containers" {
+  # checkov:skip=CKV2_AZURE_8: Application data containers (projects/backups/etc.), not activity-log storage. Access type is enforced via the var.containers schema (defaults to "private") and propagated through local.all_containers; checkov can't follow the for_each + each.value indirection through the storage_create conditional.
   for_each = var.storage_create ? { for key, value in local.all_containers : key => value } : {}
 
   name                  = "${var.deploy_id}-${each.value.name}"

--- a/storage.tf
+++ b/storage.tf
@@ -47,6 +47,7 @@ resource "azurerm_storage_account" "domino" {
 # Create Domino Shared Storage Account
 resource "azurerm_storage_account" "domino_shared" {
   #checkov:skip=CKV_AZURE_244:Local users are required for storage account key access used by AKS nodes
+  count                           = var.shared_storage_create ? 1 : 0
   name                            = "${replace(var.deploy_id, "/[_-]/", "")}${"shared"}"
   location                        = data.azurerm_resource_group.aks.location
   resource_group_name             = data.azurerm_resource_group.aks.name
@@ -95,13 +96,13 @@ resource "azurerm_private_dns_zone_virtual_network_link" "private_dns_zone_blob_
 }
 # Create a Private DNS Zone for the Storage Account shared service
 resource "azurerm_private_dns_zone" "shared_private_dns_zone" {
-  count               = local.private_shared_enabled ? 1 : 0
+  count               = local.private_shared_enabled && var.shared_storage_create ? 1 : 0
   name                = "privatelink.file.core.windows.net"
   resource_group_name = data.azurerm_resource_group.aks.name
 }
 # link the dns private zone to the AKS VNET
 resource "azurerm_private_dns_zone_virtual_network_link" "private_dns_zone_shared_vnet_link" {
-  count                 = local.private_shared_enabled ? 1 : 0
+  count                 = local.private_shared_enabled && var.shared_storage_create ? 1 : 0
   name                  = "shared-vnet-dns-link"
   resource_group_name   = data.azurerm_resource_group.aks.name
   private_dns_zone_name = azurerm_private_dns_zone.shared_private_dns_zone[0].name
@@ -126,9 +127,9 @@ module "domino_blob_ep" {
 }
 # Create a private endpoint for the fileshare Storage Account
 module "domino_shared_ep" {
-  count                 = local.private_shared_enabled ? 1 : 0
+  count                 = local.private_shared_enabled && var.shared_storage_create ? 1 : 0
   source                = "./modules/private_endpoint"
-  resource_id           = azurerm_storage_account.domino_shared.id
+  resource_id           = azurerm_storage_account.domino_shared[0].id
   nic_name              = "sa-shared-${var.deploy_id}"
   private_endpoint_name = "sa-shared-${var.deploy_id}"
   private_dns_zone      = azurerm_private_dns_zone.shared_private_dns_zone[0].name
@@ -144,8 +145,8 @@ module "domino_shared_ep" {
 #########################################################################
 # Create a storage account network rule to authorize access to shared from private endpoint
 resource "azurerm_storage_account_network_rules" "domino_shared_rules" {
-  count                      = local.private_shared_enabled ? 1 : 0
-  storage_account_id         = azurerm_storage_account.domino_shared.id
+  count                      = local.private_shared_enabled && var.shared_storage_create ? 1 : 0
+  storage_account_id         = azurerm_storage_account.domino_shared[0].id
   default_action             = "Deny"
   bypass                     = ["AzureServices"]
   virtual_network_subnet_ids = [data.azurerm_subnet.aks_subnet[0].id]
@@ -190,12 +191,23 @@ resource "azurerm_storage_container" "domino_containers" {
 #########################################################################
 # Create a fileshare for private storage
 resource "azurerm_storage_share" "shared_store" {
+  count                = var.shared_storage_create ? 1 : 0
   name                 = "shared"
-  storage_account_name = azurerm_storage_account.domino_shared.name
+  storage_account_name = azurerm_storage_account.domino_shared[0].name
   quota                = 100
 }
 
 moved {
   from = azurerm_storage_account.domino
   to   = azurerm_storage_account.domino[0]
+}
+
+moved {
+  from = azurerm_storage_account.domino_shared
+  to   = azurerm_storage_account.domino_shared[0]
+}
+
+moved {
+  from = azurerm_storage_share.shared_store
+  to   = azurerm_storage_share.shared_store[0]
 }

--- a/storage.tf
+++ b/storage.tf
@@ -180,7 +180,7 @@ locals {
   )
 }
 resource "azurerm_storage_container" "domino_containers" {
-  # checkov:skip=CKV2_AZURE_8: Application data containers (projects/backups/etc.), not activity-log storage. Access type is enforced via the var.containers schema (defaults to "private") and propagated through local.all_containers; checkov can't follow the for_each + each.value indirection through the storage_create conditional.
+  # checkov:skip=CKV2_AZURE_8: rule targets activity-log storage; these are app-data containers with access_type defaulting to "private" via the var.containers schema.
   for_each = var.storage_create ? { for key, value in local.all_containers : key => value } : {}
 
   name                  = "${var.deploy_id}-${each.value.name}"

--- a/storage.tf
+++ b/storage.tf
@@ -14,6 +14,7 @@ locals {
 # Create Domino Blob Storage Account
 resource "azurerm_storage_account" "domino" {
   #checkov:skip=CKV_AZURE_244:Local users are required for storage account key access used by AKS nodes
+  count                           = var.storage_create ? 1 : 0
   name                            = replace(var.deploy_id, "/[_-]/", "")
   location                        = data.azurerm_resource_group.aks.location
   resource_group_name             = data.azurerm_resource_group.aks.name
@@ -80,13 +81,13 @@ resource "azurerm_storage_account" "domino_shared" {
 #########################################################################
 # Create a Private DNS Zone for the Storage Account Blob service
 resource "azurerm_private_dns_zone" "blob_private_dns_zone" {
-  count               = local.private_blob_enabled ? 1 : 0
+  count               = local.private_blob_enabled && var.storage_create ? 1 : 0
   name                = "privatelink.blob.core.windows.net"
   resource_group_name = data.azurerm_resource_group.aks.name
 }
 # link the dns private zone to the AKS VNET
 resource "azurerm_private_dns_zone_virtual_network_link" "private_dns_zone_blob_vnet_link" {
-  count                 = local.private_blob_enabled ? 1 : 0
+  count                 = local.private_blob_enabled && var.storage_create ? 1 : 0
   name                  = "blob-vnet-dns-link"
   resource_group_name   = data.azurerm_resource_group.aks.name
   private_dns_zone_name = azurerm_private_dns_zone.blob_private_dns_zone[0].name
@@ -111,9 +112,9 @@ resource "azurerm_private_dns_zone_virtual_network_link" "private_dns_zone_share
 #########################################################################
 # Create a private endpoint for the Blob Storage Account
 module "domino_blob_ep" {
-  count                 = local.private_blob_enabled ? 1 : 0
+  count                 = local.private_blob_enabled && var.storage_create ? 1 : 0
   source                = "./modules/private_endpoint"
-  resource_id           = azurerm_storage_account.domino.id
+  resource_id           = azurerm_storage_account.domino[0].id
   nic_name              = "sa-blob-${var.deploy_id}"
   private_endpoint_name = "sa-blob-${var.deploy_id}"
   private_dns_zone      = azurerm_private_dns_zone.blob_private_dns_zone[0].name
@@ -152,8 +153,8 @@ resource "azurerm_storage_account_network_rules" "domino_shared_rules" {
 }
 # Create a storage account network rule to authorize access to blob from private endpoint
 resource "azurerm_storage_account_network_rules" "domino_blob_rules" {
-  count                      = local.private_blob_enabled ? 1 : 0
-  storage_account_id         = azurerm_storage_account.domino.id
+  count                      = local.private_blob_enabled && var.storage_create ? 1 : 0
+  storage_account_id         = azurerm_storage_account.domino[0].id
   default_action             = "Deny"
   bypass                     = ["AzureServices"]
   virtual_network_subnet_ids = [data.azurerm_subnet.aks_subnet[0].id]
@@ -178,13 +179,10 @@ locals {
   )
 }
 resource "azurerm_storage_container" "domino_containers" {
-  for_each = {
-    for key, value in local.all_containers :
-    key => value
-  }
+  for_each = var.storage_create ? { for key, value in local.all_containers : key => value } : {}
 
   name                  = "${var.deploy_id}-${each.value.name}"
-  storage_account_name  = azurerm_storage_account.domino.name
+  storage_account_name  = azurerm_storage_account.domino[0].name
   container_access_type = each.value.container_access_type
 }
 #########################################################################
@@ -195,4 +193,9 @@ resource "azurerm_storage_share" "shared_store" {
   name                 = "shared"
   storage_account_name = azurerm_storage_account.domino_shared.name
   quota                = 100
+}
+
+moved {
+  from = azurerm_storage_account.domino
+  to   = azurerm_storage_account.domino[0]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -111,7 +111,7 @@ variable "node_pools" {
     }),
     gpu = object({
       enable_node_public_ip = optional(bool, false)
-      vm_size               = optional(string, "Standard_NC6s_v3")
+      vm_size               = optional(string, "Standard_NC24ads_A100_v4")
       zones                 = optional(list(string), [])
       node_labels = optional(map(string), {
         "dominodatalab.com/node-pool" = "default-gpu"

--- a/variables.tf
+++ b/variables.tf
@@ -309,3 +309,9 @@ variable "workspace_audit" {
   })
   default = {}
 }
+
+variable "acr_create" {
+  description = "Whether to create the Azure Container Registry and related resources (tokens, role assignments, ACR credential refresher identity). Set to false for dataplane-only deployments that pull images from a remote registry."
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -321,3 +321,9 @@ variable "storage_create" {
   type        = bool
   default     = true
 }
+
+variable "shared_storage_create" {
+  description = "Whether to create the compute shared storage account, azurefile share, and supporting role assignments. Set to false for dataplane-only deployments using ephemeral block storage only."
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -315,3 +315,9 @@ variable "acr_create" {
   type        = bool
   default     = true
 }
+
+variable "storage_create" {
+  description = "Whether to create the projects/backups blob storage account, containers, network rules, and private endpoints. Set to false for dataplane-only deployments where projects/backups blobs live on the control plane."
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -327,3 +327,9 @@ variable "shared_storage_create" {
   type        = bool
   default     = true
 }
+
+variable "hephaestus_create" {
+  description = "Whether to create the Hephaestus image-builder managed identity and its federated credentials (hephaestus + importer). Set to false for dataplane-only deployments where image building runs on the control plane."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Adds per-resource `create` flags (`acr_create`, `storage_create`, `shared_storage_create`, `hephaestus_create`, default `true`) so the module can deploy as a dataplane without the CP-only bits (ACR, projects/backups storage, shared file storage, Hephaestus identity). `moved {}` blocks keep existing CPs drift-free. Outputs gated by those flags become nullable.

GPU default bumped to `Standard_NC24ads_A100_v4` since `NC6s_v3` retired 2025-09-30. Closes #106.

**Plan impact on existing clusters:**
- Non-GPU CP: zero diff.
- GPU CP: `gpu` node pool replaced — Azure doesn't allow in-place `vm_size` changes. Override `azure.node_pools.gpu.size` to keep it.
- If you call `lookup(module.aks.containers, key, default)` from outside the module, switch to `try(map.key, default)`. The conditional `containers` output unifies into a type that strict-default `lookup`s reject. Hit in platform-apps `aks.py:104`, fix in DOM-77016.

**Test plan**
- CI green.
- All four flags = `false` plans only AKS + node pools + log analytics + AKS-managed identity.
- platform-apps DOM-77016 will pin to `v3.0.0-rc1` after this merges + gets tagged.
