### PR TITLE
quote interpolated variables, especially the secret

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -175,7 +175,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   provisioner "local-exec" {
     command = <<-EOF
       if ! az account show 2>/dev/null; then
-        az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET -t $ARM_TENANT_ID
+        az login --service-principal --username="$ARM_CLIENT_ID" --password="$ARM_CLIENT_SECRET" --tenant="$ARM_TENANT_ID"
       fi
 
       az aks get-credentials --overwrite-existing -f ${var.kubeconfig_output_path} -n ${var.deploy_id} -g ${data.azurerm_resource_group.aks.name}


### PR DESCRIPTION
Dealing with a very flaky issue when creating Azure deployments, where the ARM_CLIENT_SECRET might contain shell breaking characters.